### PR TITLE
createOrder integrated with menuContext

### DIFF
--- a/fredes-finest/src/Components/Menu/Menu.js
+++ b/fredes-finest/src/Components/Menu/Menu.js
@@ -1,18 +1,31 @@
 import React from 'react';
 import './Menu.css';
 
-function Menu({ menuItems, showSoldOutStatus = true, onSoldOutChange }) {
+function Menu({ menuItems, addToOrder, onSoldOutChange, showSoldOutStatus = true}) {
+    console.log(addToOrder); // Temporarily log the addToOrder prop
+
+    const handleClick = (item, index) => {
+        if (addToOrder) {
+            addToOrder(item);
+        } else if (onSoldOutChange) {
+            onSoldOutChange(index);
+        }
+    };
+
     return (
         <div className="menu-container">
-            {menuItems.map((item, index) => (
-                <div key={index} className={`menu-item ${showSoldOutStatus? (item.isSoldOut? 'sold-out' : 'available') : ''}`}>
-                    <h3>{item.name}</h3>
-                    <p>{item.description}</p>
-                    {showSoldOutStatus && item.isSoldOut ? <p>Sold Out</p> : <p>Available</p>}
-                    {onSoldOutChange && <button onClick={() => onSoldOutChange(index)}>Toggle Sold Out</button>}
-                </div>
-            ))}
+        {menuItems.map((item, index) => (
+            <div 
+            key={item.id} 
+            className={`menu-item ${item.isSoldOut? 'sold-out' : 'available'}`}
+            onClick={() => handleClick(item, index)}
+        >           
+            <h3>{item.name}</h3>
+            {showSoldOutStatus && item.isSoldOut? <p>Sold Out</p> : <p>Available</p>}
+            {onSoldOutChange && <button onClick={() => onSoldOutChange(index)}>Toggle Sold Out</button>}
         </div>
+        ))}
+    </div>
     );
 }
 

--- a/fredes-finest/src/pages/Manager/Menu/CreateMenu.js
+++ b/fredes-finest/src/pages/Manager/Menu/CreateMenu.js
@@ -1,15 +1,25 @@
 import './CreateMenu.css';
 import { useMenu } from '../../../services/MenuContext';
+import React, { useState } from 'react';
+
 
 const CreateMenu = () => {
-    const { name, description, price, timeToCook, isPending, setName, setDescription, setPrice, setTimeToCook, setIsPending, addMenuItem } = useMenu();
+    const { addMenuItem } = useMenu();
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [price, setPrice] = useState('');
+    const [timeToCook, setTimeToCook] = useState('');
+    const [isSoldOut, setIsSoldOut] = useState(false);
+    const [isPending, setIsPending] = useState(false);
 
     const handleSubmit = (e) => {
         e.preventDefault();
-        const newMenuItem = { name, description, price, timeToCook };
+        setIsPending(true); 
+        const newMenuItem = { name, description, price, timeToCook, isSoldOut };
 
-        addMenuItem(newMenuItem);
-    }
+        addMenuItem(newMenuItem).then(() => {
+            setIsPending(false); // Reset isPending after submission
+        });    }
 
     return ( 
         <div className="createMenu">
@@ -54,7 +64,7 @@ const CreateMenu = () => {
                     <option value="55">55</option>
                     <option value="60">60</option>
                 </select>
-                {!isPending && <button>Add menu</button>}
+                {!isPending && <button type="submit">Add menu</button>}
                 {isPending && <button disabled>Adding menu...</button>}
             </form>
         </div>

--- a/fredes-finest/src/pages/Waiter/Orders/CreateOrder.js
+++ b/fredes-finest/src/pages/Waiter/Orders/CreateOrder.js
@@ -4,7 +4,8 @@ import './CreateOrder.css';
 import OrderItems from '../../../Components/OrderItem/OrderItems';
 import SuccesModal from '../../../Components/Dialogs/SuccesModal';
 import FailedModal from '../../../Components/Dialogs/FailedModal';
-
+import Menu from '../../../Components/Menu/Menu';
+import { useMenu } from '../../../services/MenuContext';
 
 function CreateOrder() {
     // hooks
@@ -14,29 +15,25 @@ function CreateOrder() {
     const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
     const [isSubmitFailedModalOpen, setIsSubmitFailedModalOpen] = useState(false);
     const [isAddFailedModalOpen, setIsAddFailedModalOpen] = useState(false);
+    const { menuItems } = useMenu();
 
-
-    // this should be replaced with a call to the backend to get the menu items
-    const menuItems = [
-        { id: 1, name: 'Pizza', price: 10},
-        { id: 2, name: 'Burger', price: 8 },
-        // Add more items as needed
-    ];
 
     const addToOrder = (menuItem) => {
+        if(menuItem.isSoldOut) {
+            setIsAddFailedModalOpen(true);
+        }
+        else{
         const existingItem = currentOrder.find(item => item.menuItem.id === menuItem.id);
         if (existingItem) {
-            // Increase the quantity
+            // Increase the quantity of the existing item
             setCurrentOrder(currentOrder.map(item =>
-                item.menuItem.id === menuItem.id ? { ...item, quantity: item.quantity + 1 } : item
+                item.menuItem.id === menuItem.id? {...item, quantity: item.quantity + 1} : item
             ));
         } else {
-            // Add new item
+            // Add a new item to the order
             setCurrentOrder([...currentOrder, { menuItem: menuItem, quantity: 1, comment: '' }]);
         }
-        if (false /* replace with actual condition, for instance if the menu item is marked as Soldout*/) {
-            setIsAddFailedModalOpen(true);
-          }
+        }
     };
 
     const removeFromOrder = () => {
@@ -126,18 +123,13 @@ function CreateOrder() {
                     </div>
                 </div>
                 <div className="menuColumn">
-                    <h2>Menu Items</h2>
-                    {menuItems.map((item) => (
-                        <div key={item.id} onClick={() => addToOrder(item)}>
-                            <p>{item.name} - ${item.price}</p>
-                        </div>
-                    ))}
+                <Menu menuItems={menuItems} addToOrder={addToOrder} showSoldOutStatus={true} />
                 </div>
                 <FailedModal 
                     isOpen={isAddFailedModalOpen} 
                     onRequestClose={closeModal} 
                     >
-                    Menu item was not added to the order!                
+                    Menu item sold out!                
                 </FailedModal>
             </div>
         </div>

--- a/fredes-finest/src/services/MenuContext.js
+++ b/fredes-finest/src/services/MenuContext.js
@@ -7,12 +7,13 @@ export const useMenu = () => useContext(MenuContext);
 
 export const MenuProvider = ({ children }) => {
     const [menuItems, setMenuItems] = useState([
-        { name: "Pizza Margherita", price: 10, TimeToCook: "20 minutes", isSoldOut: true },
-        { name: "Spaghetti Bolognese", price: 8, TimeToCook: "30 minutes", isSoldOut: true },
-        { name: "Chicken Parmesan", price: 12, TimeToCook: "25 minutes", isSoldOut: false },
-        { name: "Garlic Bread", price: 5, TimeToCook: "10 minutes", isSoldOut: false },
-        { name: "Tiramisu", price: 6, TimeToCook: "1 hour", isSoldOut: false }
+        { id: 1, name: "Pizza Margherita", price: 10, TimeToCook: "20 minutes", isSoldOut: true },
+        { id: 2, name: "Spaghetti Bolognese", price: 8, TimeToCook: "30 minutes", isSoldOut: true },
+        { id: 3, name: "Chicken Parmesan", price: 12, TimeToCook: "25 minutes", isSoldOut: false },
+        { id: 4, name: "Garlic Bread", price: 5, TimeToCook: "10 minutes", isSoldOut: false },
+        { id: 5, name: "Tiramisu", price: 6, TimeToCook: "1 hour", isSoldOut: false }
     ]);    
+
     const [isPending, setIsPending] = useState(true);
     const [error, setError] = useState(null);
 
@@ -71,7 +72,7 @@ export const MenuProvider = ({ children }) => {
         }, []);
 
     return (
-        <MenuContext.Provider value={{ menuItems, toggleSoldOut, isPending, error }}>
+        <MenuContext.Provider value={{ menuItems, toggleSoldOut, isPending, error , addMenuItem}}>
             {children}
         </MenuContext.Provider>
     );


### PR DESCRIPTION
CreateOrder now uses the menuContext instead of dummy data. 
It is not possible to add a menuItem if it is marked as sold out from the kitchen page. 
All integration from menu in frontend works. Not testes with backend. 